### PR TITLE
Set the minimal password length allowed

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -265,6 +265,7 @@ class User extends UserIdentity
 			['password', 'required', 'on'=>['newUser', 'changePassword']],
 			['password', 'string', 'max' => 255, 'on'=>['newUser', 'changePassword']],
 			['password', 'trim', 'on'=>['newUser', 'changePassword']],
+			[['password', 'repeat_password'], 'min'=>8],
 			['password', 'match', 'pattern' => Yii::$app->getModule('user-management')->passwordRegexp],
 			
 			['repeat_password', 'required', 'on'=>['newUser', 'changePassword']],

--- a/models/forms/ChangeOwnPasswordForm.php
+++ b/models/forms/ChangeOwnPasswordForm.php
@@ -32,7 +32,7 @@ class ChangeOwnPasswordForm extends Model
 	public function rules()
 	{
 		return [
-			[['password', 'repeat_password'], 'required'],
+			[['password', 'repeat_password'], 'required', 'string', 'min'=>8],
 			[['password', 'repeat_password', 'current_password'], 'string', 'max'=>255],
 			[['password', 'repeat_password', 'current_password'], 'trim'],
 			['password', 'match', 'pattern' => Yii::$app->getModule('user-management')->passwordRegexp],

--- a/models/forms/RegistrationForm.php
+++ b/models/forms/RegistrationForm.php
@@ -32,7 +32,7 @@ class RegistrationForm extends Model
 
 			['username', 'purgeXSS'],
 
-			['password', 'string', 'max' => 255],
+			[['password', 'repeat_password'], 'string', 'min'=>8, 'max'=>255],
 			['password', 'match', 'pattern' => Yii::$app->getModule('user-management')->passwordRegexp],
 
 			['repeat_password', 'compare', 'compareAttribute'=>'password'],


### PR DESCRIPTION
In order to show a custom error message, we need to define explicitly the rule of password shortest length allowed.